### PR TITLE
Expose carota  editor document instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@creately/carota",
   "author": "Daniel Earwicker (dan@earwicker.com)",
   "description": "Simple, flexible rich text rendering/editing on HTML Canvas",
-  "version": "2.13.3",
+  "version": "2.14.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/danielearwicker/carota.git"

--- a/src/editor.js
+++ b/src/editor.js
@@ -16,7 +16,7 @@ setInterval(function() {
         editors[n].dispatchEvent(ev);
     }
 }, 200);
-var editors = [];
+var editors = new WeakSet();
 var create = function(element, defaultFormatting, drawtext = true ) {
 
     // We need the host element to be a container:
@@ -526,7 +526,7 @@ var create = function(element, defaultFormatting, drawtext = true ) {
     doc.setZoomLevel = function( level ){ currentZoomLevel = level };
     doc.getZoomLevel = function(){ return currentZoomLevel };
     doc.focus = function(){ textArea.focus() };
-    editors.push( doc );
+    editors.add( doc );
     return doc;
 };
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -16,8 +16,8 @@ setInterval(function() {
         editors[n].dispatchEvent(ev);
     }
 }, 200);
-
-exports.create = function(element, defaultFormatting, drawtext = true ) {
+var editors = [];
+var create = function(element, defaultFormatting, drawtext = true ) {
 
     // We need the host element to be a container:
     if (dom.effectiveStyle(element, 'position') !== 'absolute') {
@@ -526,5 +526,11 @@ exports.create = function(element, defaultFormatting, drawtext = true ) {
     doc.setZoomLevel = function( level ){ currentZoomLevel = level };
     doc.getZoomLevel = function(){ return currentZoomLevel };
     doc.focus = function(){ textArea.focus() };
+    editors.push( doc );
     return doc;
 };
+
+module.exports = {
+    create,
+    editors
+}


### PR DESCRIPTION
QA requested a way to get the number of text lines that the current editor has so after this change
they can get the lines length like this, besides exposing the editor instance will be useful for other cases as well,  
`carota.editor.editors[0].frame.lines.length;`
